### PR TITLE
Add contexts to type checking rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,10 @@ OTT_FLAGS = -tex_wrap false
 all : bil.pdf
 
 bil.pdf : bil.ott bil.tex Makefile
-	ott $(OTT_FLAGS) bil.ott -o ott.tex
-	$(LATEX) bil.tex
-	$(LATEX) bil.tex
+	ott $(OTT_FLAGS) bil.ott -o ott.tex -tex_filter bil.tex bil_filtered.tex
+	$(LATEX) bil_filtered.tex
+	$(LATEX) bil_filtered.tex
+	mv bil_filtered.pdf bil.pdf
 
 clean :
-	rm -f ott.tex bil.aux bil.pdf bil.log bil.toc bil.pdf ott.aux
+	rm -f ott.tex bil.pdf bil_filtered.tex *.log *.toc *.aux

--- a/bil.ott
+++ b/bil.ott
@@ -189,7 +189,13 @@ grammar
    | mem < sz1 , sz2 >                          ::      :: mem
    {{ com -- memory with address size $sz_1$ and element size $sz_2$}}
 
- delta {{ tex \Delta}} :: delta_ ::=
+ gamma {{ tex \Gamma }}, G {{ tex \Gamma }} :: gamma_ ::=
+   | []                                         ::      :: nil  {{ com -- empty }}
+   | gamma , var                                ::      :: cons {{ com -- extend }}
+   | [ var ]                                    :: S    :: singleton {{ com -- singleton list }}
+   | ( G )                                      :: S    :: parens
+
+delta {{ tex \Delta}} :: delta_ ::=
    | []                                         ::      :: nil  {{ com -- empty }}
    | delta [ var <- val ]                       ::      :: cons {{ com -- extend }}
 
@@ -205,9 +211,12 @@ formula :: formula_ ::=
  | nat1 >= nat2             :: M :: nat_ge {{ coq ([[nat1]] >= [[nat2]])}}
  | e1 :=def e2              :: M :: defines
      {{ tex [[e1]] \stackrel{\text{def} }{:=} [[e2]] }}
- | ( var , val ) isin delta   :: M :: in_env
- | var notin dom ( delta )   :: M :: notin_env
-   {{ tex [[var]] [[notin]] \mathsf{dom}([[delta]]) }}
+ | ( var , val ) isin delta  :: M :: in_env
+ | var isin gamma            :: M :: in_ctx
+ | id notin dom ( delta )   :: M :: notin_env
+   {{ tex [[id]] [[notin]] \mathsf{dom}([[delta]]) }}
+ | id notin dom ( gamma )   :: M :: notin_ctx
+   {{ tex [[id]] [[notin]] \mathsf{dom}([[gamma]]) }}
 
 terminals :: terminals_ ::=
   | ->				::   ::	rarrow					{{ tex \rightarrow }}
@@ -224,135 +233,202 @@ terminals :: terminals_ ::=
   | <<              ::   :: lsl                     {{ tex \ll}}
   | isin        :: :: in {{ tex \in }}
   | notin     :: :: notin {{ tex \notin }}
-
+  | |_|       :: :: join {{ tex \sqcup }}
+  | dom       :: :: dom {{ tex \mathsf{dom} }}
+  | =>        :: :: newctx {{ tex \Rightarrow }}
 
 subrules
   val <:: exp
 
 defns typing_exp :: '' ::=
- defn exp '::' type :: :: type_exp :: t_ by
+ defn G |- exp '::' type :: :: type_exp :: t_ by
 
-
+ id:t isin G
  ----------------- :: var
- id:t :: t
+ G |- id:t :: t
 
  ----------------- :: int
- num:sz :: imm<sz>
+ G |- num:sz :: imm<sz>
 
- e1 :: mem<nat,sz>
- e2 :: imm<nat>
+ G |- e1 :: mem<nat,sz>
+ G |- e2 :: imm<nat>
  -------------------------- :: load
- e1 [e2, ed] : sz :: imm<sz>
+ G |- e1 [e2, ed] : sz :: imm<sz>
 
 
- e1 :: mem<nat,sz>
- e2 :: imm<nat>
- e3 :: imm<sz>
+ G |- e1 :: mem<nat,sz>
+ G |- e2 :: imm<nat>
+ G |- e3 :: imm<sz>
  --------------------------------------------- :: store
- e1 with [e2, ed]:sz <- e3 :: mem<nat,sz>
+ G |- e1 with [e2, ed]:sz <- e3 :: mem<nat,sz>
 
 
- e1 :: imm<sz>
- e2 :: imm<sz>
+ G |- e1 :: imm<sz>
+ G |- e2 :: imm<sz>
  --------------------------------- :: bop
- e1 bop e2 :: imm<sz>
+ G |- e1 bop e2 :: imm<sz>
 
 
- e1 :: imm<sz>
+ G |- e1 :: imm<sz>
  ---------------------------------- :: uop
- uop e1 :: imm<sz>
+ G |- uop e1 :: imm<sz>
 
 
- e :: imm<nat>
+ G |- e :: imm<nat>
  --------------------- :: cast
- cast:sz[e] :: imm<sz>
+ G |- cast:sz[e] :: imm<sz>
 
 
- var :: t
- e1  :: t
- e2  :: t'
+ G |- e1  :: t
+ G |_| [id:t] = G'
+ G' |- e2  :: t'
  ------------------------ :: let
- let var = e1 in e2 :: t'
+ G |- let id:t = e1 in e2 :: t'
 
 
  ------------------------- :: unknown
- unknown[str]:t :: t
+ G |- unknown[str]:t :: t
 
 
- e1 :: imm<1>
- e2 :: t
- e3 :: t
+ G |- e1 :: imm<1>
+ G |- e2 :: t
+ G |- e3 :: t
  -------------------------- :: ite
- if e1 then e2 else e3 :: t
+ G |- if e1 then e2 else e3 :: t
 
- e :: imm<sz>
+ G |- e :: imm<sz>
  sz1 >= sz2
  ---------------------------------- :: extract
- extract:sz1:sz2[e] :: imm<sz1-sz2+1>
+ G |- extract:sz1:sz2[e] :: imm<sz1-sz2+1>
 
 
- e1 :: imm<sz1>
- e2 :: imm<sz2>
+ G |- e1 :: imm<sz1>
+ G |- e2 :: imm<sz2>
  ---------------------------------- :: concat
- e1 @ e2 :: imm<sz1+sz2>
+ G |- e1 @ e2 :: imm<sz1+sz2>
+
+defns ctx_join :: '' ::=
+ defn G1 |_| G2 = G3 :: :: ctx_join :: cjoin_ by
+
+  -------------- :: nil
+  G1 |_| [] = G1
+
+
+  G1 |_| G2 = G3
+  id notin dom(G1)
+  ---------------------------- :: cons_fresh
+  G1 |_| (G2,id:t) = G3,id:t
+
+  G1 |_| G2 = G3
+  id:t isin G1
+  ---------------------------- :: cons_agree
+  G1 |_| (G2,id:t) = G3
+ 
+
+defns decl_stmt :: '' ::=
+ defn decls ( s ) = G :: :: decl_stmt :: dstmt_ by
+
+  --------------------------- :: move
+  decls(var := exp) = [var]
+
+
+  --------------------------- :: jmp
+  decls(jmp exp) = []
+
+
+  --------------------------- :: cpuexn
+  decls(cpuexn(num)) = []
+
+
+  ---------------------------- :: special
+  decls(special(str)) = []
+
+
+  decls (seq) = G
+  ---------------------------- :: while
+  decls(while (e) seq) = G
+
+
+  decls (seq) = G
+  ---------------------------- :: ifthen
+  decls(if (e) seq) = G
+
+
+  decls(seq1) = G1
+  decls(seq2) = G2
+  G1 |_| G2 = G
+  ---------------------------- :: if
+  decls(if (e) seq1 else seq2) = G
+
+
+ defn decls ( seq ) = G :: :: decl_seq :: dseq_ by
+
+ decls(s) = G
+ -------------- :: one
+ decls({s}) = G
+ 
+ decls(s1) = G1
+ decls({s2;..;sn}) = G2
+ G1 |_| G2 = G
+ --------------------- :: many
+ decls({s1;s2;..;sn}) = G
 
 
 defns typing_stmt :: '' ::=
 
- defn bil is ok :: :: type_seq :: t_ by
+ defn G |- bil => G' :: :: type_seq :: t_ by
 
- stmt is ok
+ G |- stmt => G'
  ------------------------------ :: seq_one
- {stmt}  is ok
+ G |- {stmt} => G'
 
- s1 is ok
- {s2; ..; sn} is ok
+ G1 |- s1 => G2
+ G2 |- {s2; ..; sn} => G3
  ------------------------------ :: seq_rec
- {s1; s2; ..; sn} is ok
+ G1 |- {s1; s2; ..; sn} => G3
+
+ defn G |- stmt => G' :: :: type_stmt :: t_ by
 
 
- defn stmt is ok :: :: type_stmt :: t_ by
-
-
- var :: t
- exp :: t
+ G |_| [id:t] = G'
+ G |- exp :: t
  --------------------------- :: move
- var := exp is ok
+ G |- id:t := exp => G'
 
 
- exp :: imm<nat>
+ G |- exp :: imm<nat>
  --------------------------- :: jmp
- jmp exp is ok
+ G |- jmp exp => G
 
 
  --------------------------- :: cpuexn
- cpuexn(num) is ok
+ G |- cpuexn(num) => G
 
 
  ---------------------------- :: special
- special(str) is ok
+ G |- special(str) => G
 
 
- e :: imm<1>
- seq is ok
+ G |- e :: imm<1> 
+ G |- seq => G'
  ---------------------------- :: while
- while (e) seq is ok
+ G |- while (e) seq => G'
 
 
- e :: imm<1>
- seq is ok
+ G |- e :: imm<1>
+ G |- seq => G'
  ---------------------------- :: ifthen
- if (e) seq is ok
+ G |- if (e) seq => G'
 
 
- e :: imm<1>
- seq1 is ok
- seq2 is ok
+ G1 |- e :: imm<1>
+ G1 |- seq1 => G2
+ G2 |- seq2 => G3
  ---------------------------- :: if
- if (e) seq1 else seq2 is ok
+ G1 |- if (e) seq1 else seq2 => G3
 
 
-
+ 
 
 defns program :: '' ::=
 
@@ -383,11 +459,11 @@ defns reduce_exp :: '' ::=
  defn delta |- exp ~> exp' :: :: exp :: '' by
 
  (var,v) isin delta
------------------- :: var_in
+ ------------------ :: var_in
  delta |- var ~> v
 
 
- id:type notin dom(delta)
+ id notin dom(delta)
  -------------------------------------------- :: var_unknown
  delta |- id:type ~> unknown[str]:type
 

--- a/bil.tex
+++ b/bil.tex
@@ -119,12 +119,15 @@ represented symbolically as a list of assignments:
 The following syntax is used to specify symbolic formulas in premises
 of judgments.
 
-We use $\Delta$ to denote set of bindings of variables to values. The
-$\Delta$ context is represented as list of pairs. We write
-$(var,v) \in \Delta$ to indicate that the value $v$ is the right-most
-binding of $var$ in $\Delta$.  Additionally, we write
+We use $\Gamma$ to represent ``typing contexts'' (a list of in-scope
+variables and their types) and use $\Delta$ to denote ``evaluation
+environments'' (a set of bindings of variables to values). The $\Delta$
+context is represented as list of
+pairs. We write $(var,v) \in \Delta$ to indicate that the value $v$ is
+the right-most binding of $var$'s identifier in $\Delta$.  Additionally, we write
 $\mathsf{dom}(\Delta)$ for $\Delta$'s {\em domain} (the set of
-variables for which it contains values).
+variables for which it contains values).  We deifne $var \in \Gamma$
+and $\mathsf{dom}(\Delta)$ similarly.
 
 We also add a small set of operations over natural numbers, like
 comparison and arithmetics. Natural numbers are mostly used to reason
@@ -135,6 +138,7 @@ We also add syntax for equality comparison for values and variables.
 
 
 \ottgrammartabular{
+\ottgamma\ottinterrule
 \ottdelta\ottinterrule
 }
 
@@ -163,9 +167,42 @@ semantics of an instruction is described by the $\mathit{bil}$ program.
 \section{Typing}
 \label{sec:typing}
 
-This section defines typing rules for BIL programs. Since BIL values
-bears type information with them we do not need typing environment, so
-the rules are fairly straightforward.
+This section defines typing rules for BIL programs.
+
+BIL statement-level variables represent global state, and are
+implicitly declared at their first use.  While variables carry their
+type with them, it is still necessary to track them in a context
+during type checking.  This is required to rule out programs like:
+\begin{verbatim}
+if (foo) then {x:imm<1> = 0} else {x:imm<32> = 42};
+bar
+\end{verbatim}
+Such a program would leave the type associated with {\tt x} unclear in
+{\tt bar}.
+
+To unify variables from different statements, we define a judgement
+$[[G1 |_| G2 = G3]]$, which indicates that the variable declarations
+in $[[G1]]$ and $[[G2]]$ are compatible and are combined in $[[G3]]$.
+Here, ``compatible'' means that each variable either occurs in only on
+of $[[G1]]$ and $[[G2]]$, or has the same type in both.
+
+\ottdefnsctxXXjoin
+
+We now present the typing rules for BIL statements and expressions.
+Because variables are implicitly declared at the first assignment, our
+type-checking rules captures the intuition that the collection of known
+variables may expand as the result of executing a statement.  It has
+the form $[[G1 |- s => G2]]$, which indicates that $[[s]]$ typechecks
+when $[[G1]]$ is the list of previously-encountered variables (and
+thier types), and $[[G2]]$ is an expanded context that includes any
+variables whose first use occurs in $[[s]]$.
+
+This intuition is embodied by the rule $\ottdrulename{t\_move}$, which
+checks a move instruction $[[id:t := exp]]$.  Here the premise $[[G
+    |_| [id:t] = G' ]]$ uses the previously-mentioned context union
+operation to check that the variable $id$ of type $t$ is compatible
+with the current context $[[G]]$.  This judgement does not hold if
+there's a previous binding for $id$ with a different type.
 
 \ottdefnstypingXXstmt
 


### PR DESCRIPTION
These contexts are necessary to catch typing errors where variables
are used with different types at different points in the program.

Because BIL statement variables are globals that are declared implicitly
at their first assignment, the typing rules for statements include the
context both before and after the statement.