### PR TITLE
Fixed typing rules for binary operations

### DIFF
--- a/bil.ott
+++ b/bil.ott
@@ -43,6 +43,10 @@ grammar
    {{ com -- update a storage $e_1$ with binding $e_2$ $\leftarrow$ $e_3$ }}
    | e1 bop e2                                  ::      :: binop
    {{ com -- perform binary operation on $e_1$ and $e_2$}}
+   | e1 cop e2                                  ::      :: cmpop
+   {{ com -- perform binary comparison on $e_1$ and $e_2$}}
+   | e1 sop e2                                  ::      :: shiftop
+   {{ com -- perform binary shift on $e_1$ by $e_2$}}
    | uop e1                                     ::      :: unop
    {{ com -- perform an unary operation on $e_1$}}
    | cast : nat [ e ]                           ::      :: cast
@@ -141,19 +145,24 @@ grammar
    | %                                          ::      :: mod {{ com -- modulo }}
    | %$                                         ::      :: smod {{ com -- signed modulo }}
         {{ tex \stackrel{signed} \% }}
+   | &                                          ::      :: and {{ com -- bitwise and }}
+   | |                                          ::      :: or  {{ com -- bitwise or }}
+   | xor                                        ::      :: xor {{ com -- bitwise xor }}
+
+ sop :: shiftop_ ::=
    | '<<'                                       ::      :: lshift
         {{ com -- logical shift left }}
    | '>>'                                       ::      :: rshift
         {{ com -- logical shift right }}
    | '~>>'                                      ::      :: arshift
         {{ com -- arithmetic shift right}}
-   | &                                          ::      :: and {{ com -- bitwise and }}
-   | |                                          ::      :: or  {{ com -- bitwise or }}
-   | xor                                        ::      :: xor {{ com -- bitwise xor }}
+
+ cop :: cmpop_ ::=
    | =                                          ::      :: eq  {{ com -- equality }}
    | <>                                         ::      :: neq {{ com -- non-equality }}
    | <                                          ::      :: lt  {{ com -- less than }}
-   | '<='                                       ::      :: le  {{ com -- less than or equal}}
+   | '<='                                       ::      :: le
+        {{ tex \leq }} {{ com -- less than or equal}}
    | '<$'                                       ::      :: slt {{ com -- signed less than}}
         {{ tex \stackrel{signed} < }}
    | '<=$'                                      ::      :: sle
@@ -277,6 +286,15 @@ defns typing_exp :: '' ::=
  --------------------------------- :: bop
  G |- e1 bop e2 :: imm<sz>
 
+ G |- e1 :: imm<sz>
+ G |- e2 :: imm<nat>
+ --------------------------------- :: sop
+ G |- e1 sop e2 :: imm<sz>
+
+ G |- e1 :: imm<sz>
+ G |- e2 :: imm<sz>
+ --------------------------------- :: cop
+ G |- e1 cop e2 :: imm<1>
 
  G |- e1 :: imm<sz>
  ---------------------------------- :: uop
@@ -493,7 +511,7 @@ defns reduce_exp :: '' ::=
  ----------------------------------------------- :: ite_true
  delta |- if true then e2 else e3 ~> e2
 
- 
+
  ------------------------------------------------ :: ite_false
  delta |- if false then e2 else e3 ~> e3
 
@@ -506,6 +524,21 @@ defns reduce_exp :: '' ::=
  ----------------------------------------- :: bop_lhs
  delta |- e1 bop v2 ~> e1' bop v2
 
+ delta |- e2 ~> e2'
+ ------------------------------------------ :: sop_rhs
+ delta |- e1 sop e2 ~> e1 sop e2'
+
+ delta |- e1 ~> e1'
+ ----------------------------------------- :: sop_lhs
+ delta |- e1 sop v2 ~> e1' sop v2
+
+ delta |- e2 ~> e2'
+ ------------------------------------------ :: cop_rhs
+ delta |- e1 cop e2 ~> e1 cop e2'
+
+ delta |- e1 ~> e1'
+ ----------------------------------------- :: cop_lhs
+ delta |- e1 cop v2 ~> e1' cop v2
 
  -------------------------------------------------------- :: bop_unk_rhs
  delta |- e bop unknown[str]:t ~> unknown[str]:t
@@ -513,6 +546,18 @@ defns reduce_exp :: '' ::=
  -------------------------------------------------------- :: bop_unk_lhs
  delta |- unknown[str]:t bop e ~> unknown[str]:t
 
+ G |- e :: t'
+ -------------------------------------------------------- :: sop_unk_rhs
+ delta |- e sop unknown[str]:t ~> unknown[str]:t'
+
+ -------------------------------------------------------- :: sop_unk_lhs
+ delta |- unknown[str]:t sop e ~> unknown[str]:t
+
+ -------------------------------------------------------- :: cop_unk_rhs
+ delta |- e cop unknown[str]:t ~> unknown[str]:imm<1>
+
+ -------------------------------------------------------- :: cop_unk_lhs
+ delta |- unknown[str]:t cop e ~> unknown[str]:imm<1>
 
  -------------------------------------- :: plus
  delta |- w1 + w2 ~> w1 .+ w2

--- a/bil.ott
+++ b/bil.ott
@@ -43,10 +43,6 @@ grammar
    {{ com -- update a storage $e_1$ with binding $e_2$ $\leftarrow$ $e_3$ }}
    | e1 bop e2                                  ::      :: binop
    {{ com -- perform binary operation on $e_1$ and $e_2$}}
-   | e1 cop e2                                  ::      :: cmpop
-   {{ com -- perform binary comparison on $e_1$ and $e_2$}}
-   | e1 sop e2                                  ::      :: shiftop
-   {{ com -- perform binary shift on $e_1$ by $e_2$}}
    | uop e1                                     ::      :: unop
    {{ com -- perform an unary operation on $e_1$}}
    | cast : nat [ e ]                           ::      :: cast
@@ -134,8 +130,11 @@ grammar
         {{ com -- signed extract/extend }}
 
 
-
  bop :: binop_ ::=
+   | aop                                      ::      :: arith  {{ com -- arithmetic operators}}
+   | lop                                      ::      :: logical  {{ com -- logical operators}}
+
+ aop :: arithop_ ::=
    | +                                          ::      :: plus  {{ com -- plus}}
    | -                                          ::      :: minus {{ com -- minus}}
    | *                                          ::      :: times {{ com -- times}}
@@ -148,8 +147,6 @@ grammar
    | &                                          ::      :: and {{ com -- bitwise and }}
    | |                                          ::      :: or  {{ com -- bitwise or }}
    | xor                                        ::      :: xor {{ com -- bitwise xor }}
-
- sop :: shiftop_ ::=
    | '<<'                                       ::      :: lshift
         {{ com -- logical shift left }}
    | '>>'                                       ::      :: rshift
@@ -157,7 +154,7 @@ grammar
    | '~>>'                                      ::      :: arshift
         {{ com -- arithmetic shift right}}
 
- cop :: cmpop_ ::=
+ lop :: logicop_ ::=
    | =                                          ::      :: eq  {{ com -- equality }}
    | <>                                         ::      :: neq {{ com -- non-equality }}
    | <                                          ::      :: lt  {{ com -- less than }}
@@ -286,18 +283,13 @@ defns typing_exp :: '' ::=
 
  G |- e1 :: imm<sz>
  G |- e2 :: imm<sz>
- --------------------------------- :: bop
- G |- e1 bop e2 :: imm<sz>
-
- G |- e1 :: imm<sz>
- G |- e2 :: imm<nat>
- --------------------------------- :: sop
- G |- e1 sop e2 :: imm<sz>
+ --------------------------------- :: aop
+ G |- e1 aop e2 :: imm<sz>
 
  G |- e1 :: imm<sz>
  G |- e2 :: imm<sz>
- --------------------------------- :: cop
- G |- e1 cop e2 :: imm<1>
+ --------------------------------- :: lop
+ G |- e1 lop e2 :: imm<1>
 
  G |- e1 :: imm<sz>
  ---------------------------------- :: uop
@@ -521,46 +513,23 @@ defns reduce_exp :: '' ::=
 
  delta |- e2 ~> e2'
  ------------------------------------------ :: bop_rhs
- delta |- e1 bop e2 ~> e1 bop e2'
+ delta |- v1 bop e2 ~> v1 bop e2'
 
  delta |- e1 ~> e1'
  ----------------------------------------- :: bop_lhs
- delta |- e1 bop v2 ~> e1' bop v2
+ delta |- e1 bop e2 ~> e1' bop e2
 
- delta |- e2 ~> e2'
- ------------------------------------------ :: sop_rhs
- delta |- e1 sop e2 ~> e1 sop e2'
+ -------------------------------------------------------- :: aop_unk_rhs
+ delta |- e aop unknown[str]:t ~> unknown[str]:t
 
- delta |- e1 ~> e1'
- ----------------------------------------- :: sop_lhs
- delta |- e1 sop v2 ~> e1' sop v2
+ -------------------------------------------------------- :: aop_unk_lhs
+ delta |- unknown[str]:t aop e ~> unknown[str]:t
 
- delta |- e2 ~> e2'
- ------------------------------------------ :: cop_rhs
- delta |- e1 cop e2 ~> e1 cop e2'
+ -------------------------------------------------------- :: lop_unk_rhs
+ delta |- e lop unknown[str]:t ~> unknown[str]:imm<1>
 
- delta |- e1 ~> e1'
- ----------------------------------------- :: cop_lhs
- delta |- e1 cop v2 ~> e1' cop v2
-
- -------------------------------------------------------- :: bop_unk_rhs
- delta |- e bop unknown[str]:t ~> unknown[str]:t
-
- -------------------------------------------------------- :: bop_unk_lhs
- delta |- unknown[str]:t bop e ~> unknown[str]:t
-
- dom(delta) |- e :: t'
- -------------------------------------------------------- :: sop_unk_rhs
- delta |- e sop unknown[str]:t ~> unknown[str]:t'
-
- -------------------------------------------------------- :: sop_unk_lhs
- delta |- unknown[str]:t sop e ~> unknown[str]:t
-
- -------------------------------------------------------- :: cop_unk_rhs
- delta |- e cop unknown[str]:t ~> unknown[str]:imm<1>
-
- -------------------------------------------------------- :: cop_unk_lhs
- delta |- unknown[str]:t cop e ~> unknown[str]:imm<1>
+ -------------------------------------------------------- :: lop_unk_lhs
+ delta |- unknown[str]:t lop e ~> unknown[str]:imm<1>
 
  -------------------------------------- :: plus
  delta |- w1 + w2 ~> w1 .+ w2

--- a/bil.ott
+++ b/bil.ott
@@ -207,6 +207,9 @@ grammar
    | gamma , var                                ::      :: cons {{ com -- extend }}
    | [ var ]                                    :: S    :: singleton {{ com -- singleton list }}
    | ( G )                                      :: S    :: parens
+   | dom( delta )                               :: M    :: dom_delta
+   {{ tex \mathsf{dom}([[delta]])}}
+   {{ com -- domain of a runtime binding context}}
 
 formula :: formula_ ::=
  | judgement                ::   :: judgement
@@ -546,7 +549,7 @@ defns reduce_exp :: '' ::=
  -------------------------------------------------------- :: bop_unk_lhs
  delta |- unknown[str]:t bop e ~> unknown[str]:t
 
- G |- e :: t'
+ dom(delta) |- e :: t'
  -------------------------------------------------------- :: sop_unk_rhs
  delta |- e sop unknown[str]:t ~> unknown[str]:t'
 

--- a/bil.tex
+++ b/bil.tex
@@ -64,8 +64,8 @@ substitution of $e_1$ for free occurances of $var$ in $e_2$
 
 \ottgrammartabular{
 \ottbop\ottinterrule
-\ottsop\ottinterrule
-\ottcop\ottinterrule
+\ottaop\ottinterrule
+\ottlop\ottinterrule
 \ottuop\ottinterrule
 \ottendian\ottinterrule
 \ottcast\ottinterrule

--- a/bil.tex
+++ b/bil.tex
@@ -114,6 +114,16 @@ represented symbolically as a list of assignments:
 \ottval\ottinterrule
 }
 
+\subsection{Context syntax}
+\label{sec:context}
+
+Contexts are used in the typing judgments to specify the types of all
+variables. While each variable is annotated with its type, the context
+ensures that all uses of a given variable have the same type.
+
+\ottgrammartabular{
+\ottgamma\ottinterrule
+}
 
 \subsection{Formula syntax}
 \label{sec:formula}

--- a/bil.tex
+++ b/bil.tex
@@ -64,6 +64,8 @@ substitution of $e_1$ for free occurances of $var$ in $e_2$
 
 \ottgrammartabular{
 \ottbop\ottinterrule
+\ottsop\ottinterrule
+\ottcop\ottinterrule
 \ottuop\ottinterrule
 \ottendian\ottinterrule
 \ottcast\ottinterrule


### PR DESCRIPTION
I'm picking up where @ccasin left off with the BIL semantics. This pull request fixes type soundness issues with the typing rules for binary operations. The static rules defined here also now line up with the actual BAP implementation.

The dynamic rules had some tricky issues revolving around `unknown[str] : t` and binary operations. Specifically, while terms of the form `e bop unknown[str] : t` under the old definition of `bop` do not always have type `t`, they always step to `unknown[str] : t`. This comes up with both comparison operations and shifts, which are separated into different categories in this pull request. The comparison case is simple since the resulting unknown can be given type `imm<1>`, but the shift case is trickier. A shift term (as per the BAP implementation) should have the type of its left argument. However, to annotate the resulting unknown with `e`'s type requires typechecking `e` in the evaluation rule.